### PR TITLE
Fix numTokens call.

### DIFF
--- a/lib/pdfcrowd.rb
+++ b/lib/pdfcrowd.rb
@@ -352,7 +352,8 @@ module Pdfcrowd
     end
 
     def rename_post_data(extra_data={})
-        result = extra_data.clone()
+        result = {}
+        extra_data.each { |key, val| result[key] = val if val }
         @fields.each { |key, val| result[key] = val if val }
         result
     end


### PR DESCRIPTION
This was calling the api with a blank src parameter, which caused it to return a 400 (presumably because it couldn't parse the POST data).  I reproduced this with curl:

```
$ curl -d "src&username=foo&key=bar" "http://pdfcrowd.com/api/user/foo/tokens/"
Missing username or/and the api key
```

```
$ curl -d "username=foo&key=bar" "http://pdfcrowd.com/api/user/foo/tokens/"
84
```

This update omits the src param if the value is blank.
